### PR TITLE
fix: add missing Dynatrace Intelligence badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- markdownlint-disable-next-line -->
 # <img src="https://cdn.bfldr.com/B686QPH3/at/w5hnjzb32k5wcrcxnwcx4ckg/Dynatrace_signet_RGB_HTML.svg?auto=webp&format=pngg" alt="DT logo" width="30"> Bug Busters Bug Finding Expedition 📋
 
+[![Dynatrace](https://img.shields.io/badge/Dynatrace-Intelligence-purple?logo=dynatrace&logoColor=white)](https://dynatrace-wwse.github.io/codespaces-framework/dynatrace-integration/#mcp-server-integration)
 [![Mastering](https://img.shields.io/badge/powered_by-DT_enablement-8A2BE2?logo=dynatrace)](https://dynatrace-wwse.github.io/codespaces-framework/)
 [![Downloads](https://img.shields.io/docker/pulls/shinojosa/dt-enablement?logo=docker)](https://hub.docker.com/r/shinojosa/dt-enablement)
 [![Integration tests](https://github.com/dynatrace-wwse/bug-busters/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/dynatrace-wwse/bug-busters/actions)


### PR DESCRIPTION
Adds the Dynatrace Intelligence badge to match the standard badge set across all repos.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>