### PR TITLE
chore: sync framework @ 1.3.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   /*
   // Building the image from the Dockerfile
   "build": {
-    "dockerfile": "Dockerfile"
+    "image": "shinojosa/dt-enablement:v1.2"
     },
     */
   // When running locally we pass the 'secrets' as env variables via runArgs "--env-file",".devcontainer/.env"

--- a/.devcontainer/test/integration.sh
+++ b/.devcontainer/test/integration.sh
@@ -16,4 +16,4 @@ assertRunningApp todoapp
 
 assertRunningPod bugzapper bugzapper
 
-assertRunningApp 30200
+assertRunningApp bugzapper

--- a/.devcontainer/test/integration.sh
+++ b/.devcontainer/test/integration.sh
@@ -12,7 +12,7 @@ assertRunningPod dynatrace oneagent
 
 assertRunningPod todoapp todoapp
 
-assertRunningApp 30100
+assertRunningApp todoapp
 
 assertRunningPod bugzapper bugzapper
 

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.2.7}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.0}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- markdownlint-disable-next-line -->
 # <img src="https://cdn.bfldr.com/B686QPH3/at/w5hnjzb32k5wcrcxnwcx4ckg/Dynatrace_signet_RGB_HTML.svg?auto=webp&format=pngg" alt="DT logo" width="30"> Bug Busters Bug Finding Expedition 📋
 
+[![Dynatrace](https://img.shields.io/badge/Dynatrace-Intelligence-purple?logo=dynatrace&logoColor=white)](https://dynatrace-wwse.github.io/codespaces-framework/dynatrace-integration/#mcp-server-integration)
 [![Mastering](https://img.shields.io/badge/powered_by-DT_enablement-8A2BE2?logo=dynatrace)](https://dynatrace-wwse.github.io/codespaces-framework/)
 [![Downloads](https://img.shields.io/docker/pulls/shinojosa/dt-enablement?logo=docker)](https://hub.docker.com/r/shinojosa/dt-enablement)
 [![Integration tests](https://github.com/dynatrace-wwse/bug-busters/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/dynatrace-wwse/bug-busters/actions)


### PR DESCRIPTION
## Sync update

- Bumps `FRAMEWORK_VERSION` from `1.2.7` to `1.3.0`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.