### PR TITLE
fix: switch to K3d + AppOnly monitoring (Sysbox-compatible)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,13 +5,13 @@ source .devcontainer/util/source_framework.sh
 
 setUpTerminal
 
-startKindCluster
+startK3dCluster
 
 installK9s
 
 dynatraceDeployOperator
 
-deployCloudNative
+deployApplicationMonitoring
 
 deployTodoApp
 


### PR DESCRIPTION
## Summary
- Replace `startKindCluster` with `startK3dCluster` in `.devcontainer/post-create.sh`
- Replace `deployCloudNative` with `deployApplicationMonitoring` in `.devcontainer/post-create.sh`

## Why — Kind → K3d
Kind requires 4-level container nesting (Kind → Docker → Sysbox → EC2). Sysbox only supports 3 levels. Result: all pods stuck in `ContainerCreating` indefinitely on every nightly run.

K3d works at 3 levels and has been the framework default since v1.3.0.

## Why — CloudNative → AppOnly
CloudNative FullStack (CNFS) uses a DaemonSet with kernel-level hooks that are incompatible with K3d inside Sysbox. Only AppOnly (webhook injection via `deployApplicationMonitoring`) works in this environment.

## Test plan
- [ ] Nightly CI run passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)