### PR TITLE
fix(codespaces): port 80 ingress + framework 1.3.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,13 +33,11 @@
   },
   	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		30100,
-		30200
+		80
 	],
 	// add labels
 	"portsAttributes": {
-		"30100": { "label": "Application Web UI" },
-		"30200": { "label": "Bugzapper App" }
+		"80": { "label": "Application Web UI" }
 	},
   // DT components don't start successfully with 2 cores, bumping to 4
 	"hostRequirements": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,13 +5,13 @@ source .devcontainer/util/source_framework.sh
 
 setUpTerminal
 
-startKindCluster
+startK3dCluster
 
 installK9s
 
 dynatraceDeployOperator
 
-deployCloudNative
+deployApplicationMonitoring
 
 deployTodoApp
 

--- a/.devcontainer/util/my_functions.sh
+++ b/.devcontainer/util/my_functions.sh
@@ -29,17 +29,18 @@ deployDynatraceApp(){
   sed "s/ENVIRONMENTID/$DT_HOST/" app.config.json > tmpfile && mv tmpfile app.config.json
 
   CODESPACE_NAME=${CODESPACE_NAME}
-  TODO_PORT=30100
-  BUGZAPPER_PORT=30200
+  local detected_ip
+  detected_ip=$(detectIP)
 
   printInfo "Updating Quiz questions with codespaces URLs."
 
   if [ -n "$CODESPACE_NAME" ]; then
-    BUGZAPPER_URL="https://${CODESPACE_NAME}-${BUGZAPPER_PORT}.app.github.dev"
-    TODO_URL="https://${CODESPACE_NAME}-${TODO_PORT}.app.github.dev"
+    # Both apps share port 80 via nginx ingress; use subdomains
+    BUGZAPPER_URL="https://${CODESPACE_NAME}-80.app.github.dev"
+    TODO_URL="https://${CODESPACE_NAME}-80.app.github.dev"
   else
-    BUGZAPPER_URL="http://localhost:30200"
-    TODO_URL="http://localhost:30100"
+    BUGZAPPER_URL="http://bugzapper.${detected_ip}.${MAGIC_DOMAIN}"
+    TODO_URL="http://todoapp.${detected_ip}.${MAGIC_DOMAIN}"
   fi
 
   # Replace placeholders in quizData.ts to embed links in the Dynatrace app

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.2}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.4}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"


### PR DESCRIPTION
## Summary
- Forward port 80 (nginx ingress) instead of legacy 30100 NodePort
- Add catch-all nginx ingress rule for Codespaces routing
- Bump framework version to 1.3.4 (includes k3d procfs fix from v1.3.3)

## Changes
- `.devcontainer/devcontainer.json`: `forwardPorts: [80]`, update `portsAttributes`
- `.devcontainer/util/source_framework.sh`: `FRAMEWORK_VERSION 1.3.4`