### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/1-bugzappers-bugs.md
+++ b/docs/1-bugzappers-bugs.md
@@ -1,4 +1,3 @@
---8<-- "snippets/bugzappers-bugs.js"
 
 ## Bug 1: Why are the top scores not being cleared?
 There are a few bugs in the Bugzapper app and your mission is to find them by investigating the application and using Dynatrace to help your investigation.

--- a/docs/2-todoapp-bugs.md
+++ b/docs/2-todoapp-bugs.md
@@ -1,4 +1,3 @@
---8<-- "snippets/3-codespaces.js"
 
 ## Bug 1: Todo App - Clear completed tasks
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/cleanup.js"
 
 --8<-- "snippets/feedback.md"
 

--- a/docs/codespaces.md
+++ b/docs/codespaces.md
@@ -1,5 +1,4 @@
 # Codespaces
---8<-- "snippets/codespaces.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/getting-started.js"
 --8<-- "snippets/grail-requirements.md"
 
 ## 1. Dynatrace Tenant Setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/index.js"
 --8<-- "snippets/disclaimer.md"
 
 ## Dynatrace Bug Buster Bug Finding Expedition

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/2-getting-started.js
+++ b/docs/snippets/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"});
-});
-</script>

--- a/docs/snippets/3-codespaces.js
+++ b/docs/snippets/3-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"});
-});
-</script>

--- a/docs/snippets/bugzappers-bugs.js
+++ b/docs/snippets/bugzappers-bugs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Bugzappers"});
-});
-</script>

--- a/docs/snippets/cleanup.js
+++ b/docs/snippets/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Cleanup"});
-});
-</script>

--- a/docs/snippets/index.js
+++ b/docs/snippets/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"});
-});
-</script>

--- a/docs/snippets/todoapp-bugs.js
+++ b/docs/snippets/todoapp-bugs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. To-do App"});
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)