### PR TITLE
fix(post-create): validate Dynatrace credentials before deploy

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,6 +3,12 @@
 export SECONDS=0
 source .devcontainer/util/source_framework.sh
 
+# Validate the Dynatrace credentials declared in devcontainer.json (secrets).
+# Codespaces silently omits unset secrets, so without this the container can
+# half-create and later DT deploy steps fail with no clear cause. Fail loudly
+# instead. The validator logs missing vars by name only (never the values).
+variablesNeeded DT_ENVIRONMENT:true DT_OPERATOR_TOKEN:true DT_INGEST_TOKEN:false || exit 1
+
 setUpTerminal
 
 startK3dCluster


### PR DESCRIPTION
## What
Add the credential validator before `dynatraceDeployOperator` in `post-create.sh`:

```bash
variablesNeeded DT_ENVIRONMENT:true DT_OPERATOR_TOKEN:true DT_INGEST_TOKEN:false || exit 1
```

## Why
This repo deploys the Dynatrace Operator. Codespaces silently omits unset secrets, so a missing `DT_OPERATOR_TOKEN`/`DT_ENVIRONMENT` half-creates the container and the deploy later fails with no clear cause. The validator fails loudly, reporting missing vars **by name only** (never the value). Mirrors `enablement-kubernetes-101`.

Part of the DEPLOYS-DT validation batch. Framework guard: dynatrace-wwse/codespaces-framework#87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)